### PR TITLE
Change from powf to sqrtf

### DIFF
--- a/s2cnn/s2_mm.py
+++ b/s2cnn/s2_mm.py
@@ -202,7 +202,7 @@ __global__ void main_(const float* in_x, const float* in_y, float* out) {
 def _setup_s2mm_gradx_cuda_kernel(nbatch, nspec, nl, nfeature_in, nfeature_out, device=0):
     kernel = Template('''
 #define COMPUTE_LM(s) \
-    int l = powf(s, 0.5); \
+    int l = sqrtf(s); \
     int L = (4 * l * l - 1) * l / 3; \
     int m = s - l * l - l;
 

--- a/s2cnn/soft/s2_fft.py
+++ b/s2cnn/soft/s2_fft.py
@@ -150,7 +150,7 @@ def _setup_s2_fft(b, nl, weighted):
 def _setup_s2fft_cuda_kernel(b, nspec, nbatch, device=0):
     kernel = Template('''
 #define COMPUTE_LM(s) \
-    int l = powf(s, 0.5); \
+    int l = sqrtf(s); \
     int m = (s - l * l) - l;
 
 #define MOD(i, n) (((i) + (n)) % (n))


### PR DESCRIPTION
See Issue #41 . The FFT coefficients of certain frequencies were inaccurate due to numeric/rounding errors in powf(s, 0.5).