### PR TITLE
Fixed breaking changes in torch.fft package in PyTorch 1.8

### DIFF
--- a/s2cnn/soft/s2_fft.py
+++ b/s2cnn/soft/s2_fft.py
@@ -35,7 +35,7 @@ def s2_fft(x, for_grad=False, b_out=None):
     wigner = _setup_wigner(b_in, nl=b_out, weighted=not for_grad, device=x.device)
     wigner = wigner.view(2 * b_in, -1)  # [beta, l * m] (2 * b_in, nspec)
 
-    x = torch.fft(x, 1)  # [batch, beta, m, complex]
+    x = torch.fft.fft(x, 1)  # [batch, beta, m, complex]
 
     output = x.new_empty((nspec, nbatch, 2))
     if x.is_cuda and x.dtype == torch.float32:
@@ -100,7 +100,7 @@ def s2_ifft(x, for_grad=False, b_out=None):
             if l > 0:
                 output[:, :, -l:] += out[:, :, :l]
 
-    output = torch.ifft(output, 1) * output.size(-2)  # [batch, beta, alpha, complex]
+    output = torch.fft.ifft(output, 1) * output.size(-2)  # [batch, beta, alpha, complex]
     output = output.view(*batch_size, 2 * b_out, 2 * b_out, 2)
     return output
 

--- a/s2cnn/soft/so3_fft.py
+++ b/s2cnn/soft/so3_fft.py
@@ -34,7 +34,7 @@ def so3_fft(x, for_grad=False, b_out=None):
 
     wigner = _setup_wigner(b_in, nl=b_out, weighted=not for_grad, device=x.device)  # [beta, l * m * n]
 
-    x = torch.fft(x, 2)  # [batch, beta, m, n, complex]
+    x = torch.fft.fft(x, 2)  # [batch, beta, m, n, complex]
 
     output = x.new_empty((nspec, nbatch, 2))
     if x.is_cuda and x.dtype == torch.float32:
@@ -87,12 +87,12 @@ def so3_rfft(x, for_grad=False, b_out=None):
 
     output = x.new_empty((nspec, nbatch, 2))
     if x.is_cuda and x.dtype == torch.float32:
-        x = torch.rfft(x, 2)  # [batch, beta, m, n, complex]
+        x = torch.fft.rfft(x, 2)  # [batch, beta, m, n, complex]
         cuda_kernel = _setup_so3fft_cuda_kernel(b_in=b_in, b_out=b_out, nbatch=nbatch, real_input=True, device=x.device.index)
         cuda_kernel(x, wigner, output)
     else:
         # TODO use torch.rfft
-        x = torch.fft(torch.stack((x, torch.zeros_like(x)), dim=-1), 2)
+        x = torch.fft.fft(torch.stack((x, torch.zeros_like(x)), dim=-1), 2)
         if b_in < b_out:
             output.fill_(0)
         for l in range(b_out):
@@ -151,7 +151,7 @@ def so3_ifft(x, for_grad=False, b_out=None):
                 output[:, :, :l1 + 1, -l1:] += out[:, :, l: l + l1 + 1, l - l1: l]
                 output[:, :, -l1:, -l1:] += out[:, :, l - l1: l, l - l1: l]
 
-    output = torch.ifft(output, 2) * output.size(-2) ** 2  # [batch, beta, alpha, gamma, complex]    
+    output = torch.fft.ifft(output, 2) * output.size(-2) ** 2  # [batch, beta, alpha, gamma, complex]    
     output = output.view(*batch_size, 2 * b_out, 2 * b_out, 2 * b_out, 2)
     return output
 
@@ -195,7 +195,7 @@ def so3_rifft(x, for_grad=False, b_out=None):
                 output[:, :, :l1 + 1, -l1:] += out[:, :, l: l + l1 + 1, l - l1: l]
                 output[:, :, -l1:, -l1:] += out[:, :, l - l1: l, l - l1: l]
 
-    output = torch.ifft(output, 2) * output.size(-2) ** 2  # [batch, beta, alpha, gamma, complex]
+    output = torch.fft.ifft(output, 2) * output.size(-2) ** 2  # [batch, beta, alpha, gamma, complex]
     output = output[..., 0]  # [batch, beta, alpha, gamma]
     output = output.contiguous()
 


### PR DESCRIPTION
I fixed to functions calls to perform Fourier Transforms and Inverse Fourier transform in [s2_fft](https://github.com/jonas-koehler/s2cnn/blob/master/s2cnn/soft/s2_fft.py) and [so3_fft](https://github.com/jonas-koehler/s2cnn/blob/master/s2cnn/soft/so3_fft.py)

`torch.fft` and `torch.ifft()` functions are now called as `torch.fft.fft()` and `torch.fft.ifft()` in PyTorch 1.8