### PR TITLE
fix bilinear interpolation in MNIST gendata

### DIFF
--- a/examples/mnist/gendata.py
+++ b/examples/mnist/gendata.py
@@ -127,8 +127,8 @@ def sample_bilinear(signal, rx, ry):
     iy = ry.astype(int)
 
     # obtain four sample coordinates
-    ix0 = ix - 1
-    iy0 = iy - 1
+    ix0 = ix
+    iy0 = iy
     ix1 = ix + 1
     iy1 = iy + 1
 


### PR DESCRIPTION
This fixes some strange artefacts in the spherical MNIST data generation.

Before fix: 
![before](https://github.com/user-attachments/assets/cf8d26ff-df06-4c09-af87-4cf78a883f81)

After:
![after](https://github.com/user-attachments/assets/4e0ea97c-4eca-4a9f-b677-6f0fcc9e1b3e)
